### PR TITLE
Add oidc auth client import to enable pulling secrets from oidc clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	flag "github.com/spf13/pflag"


### PR DESCRIPTION
I missed in the client-go docs that you need to import these auth
clients when using various k8s clusters. Only use of this I know of so
far is oidc so just importing that one for now. Should be able to import
more if needed later.